### PR TITLE
fixed deprecation warning in class CapsuleLoss

### DIFF
--- a/Capsule_Network.ipynb
+++ b/Capsule_Network.ipynb
@@ -755,7 +755,7 @@
     "    def __init__(self):\n",
     "        '''Constructs a CapsuleLoss module.'''\n",
     "        super(CapsuleLoss, self).__init__()\n",
-    "        self.reconstruction_loss = nn.MSELoss(size_average=False)\n",
+    "        self.reconstruction_loss = nn.MSELoss(reduction='sum')\n",
     "\n",
     "    def forward(self, x, labels, images, reconstructions):\n",
     "        '''Defines how the loss compares inputs.\n",


### PR DESCRIPTION
in nn.MSELoss - now using reduction='sum' instead of size_average='False' as suggested in the doc page.
https://pytorch.org/docs/stable/nn.html#mseloss